### PR TITLE
[Feat] Add Reusable Input Component

### DIFF
--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import Image from 'next/image';
+// Input 사용 시 필요한 props
+// name: input의 이름
+// type: input의 타입
+// passwordToMatch: 비밀번호 확인 시 비교할 비밀번호
+// onChange: input 값 변경 시 실행할 함수
+interface InputProps {
+  name: string;
+  type: string;
+  passwordToMatch?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+export default function Input({ name, type, passwordToMatch, onChange }: InputProps) {
+  const [value, setValue] = useState('');
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+  const [isVisible, setIsVisible] = useState(false); // 비밀번호 보이기/숨기기 상태
+  const setting = {
+    name: {
+      labelName: '이름',
+      placeholderText: '이름을 입력해주세요.',
+      invalidText: '이름은 3자 이상이어야 합니다.',
+      validate: (val: string) => val.length >= 3,
+    },
+    id: {
+      labelName: '아이디',
+      placeholderText: '이메일을 입력해주세요.',
+      invalidText: '이메일 형식이 올바르지 않습니다.',
+      validate: (val: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val),
+    },
+    password: {
+      labelName: '비밀번호',
+      placeholderText: '비밀번호를 입력해주세요.',
+      invalidText: '비밀번호는 8자 이상이어야 합니다.',
+      validate: (val: string) => val.length >= 8,
+    },
+    password_check: {
+      labelName: '비밀번호 확인',
+      placeholderText: '비밀번호를 다시 입력해주세요.',
+      invalidText: '비밀번호가 일치하지 않습니다.',
+      validate: (val: string) => val == passwordToMatch,
+    },
+  };
+  const { placeholderText, invalidText, validate, labelName } = setting[name] || {};
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setValue(inputValue);
+    setIsValid(validate ? validate(inputValue) : true);
+    if (onChange) {
+      onChange(e);
+    }
+  };
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
+  return (
+    <div className="relative w-full">
+      <label htmlFor={type}>{labelName}</label>
+      <input
+        id={type}
+        placeholder={placeholderText[type]}
+        name={type}
+        type={type === 'password' && isVisible ? 'text' : type}
+        value={value}
+        onChange={handleChange}
+        className={`w-full rounded-xl border-2 bg-gray-100 p-2 px-4 ${isValid ? 'border-gray-300 focus:border-blue-500' : 'border-red-500 focus:border-red-500'}`}
+      />
+      {type === 'password' && (
+        <button type="button" onClick={toggleVisibility} className="absolute right-2 top-8 text-gray-600">
+          {isVisible ? (
+            <Image src="icons/visibility-on.svg" alt="eye-on" width={24} height={24} />
+          ) : (
+            <Image src="icons/visibility-off.svg" alt="eye-off" width={24} height={24} />
+          )}
+        </button>
+      )}
+      {!isValid && <p className="mt-1 text-sm text-red-500">{invalidText}</p>}
+    </div>
+  );
+}

--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -1,20 +1,24 @@
 import { useState } from 'react';
 import Image from 'next/image';
 
-/**
-  *** Input 사용 시 필요한 props ***
-  - name: input의 이름
-  - type: input의 타입
-  - passwordToMatch: 비밀번호 확인 시 비교할 비밀번호
-  - onChange: input 값 변경 시 실행할 함수
- */
-
 interface InputProps {
   type: 'text' | 'email' | 'password';
   name: 'name' | 'id' | 'password' | 'password_check';
   passwordToMatch?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
+
+/**
+ Input Component
+ * @description Resuable Input Component by using parameter of name, type, passwordToMatch. 
+ * onChange를 적용하여 원하는 value를 전 컴포넌트에 가져올 수 있다.
+ * 추가하고 싶은 type이 있다면 setting에 추가하여 사용하면 된다.
+ *
+ * @param type - text, email, password
+ * @param name - name, id, password, password_check
+ * @param passwordToMatch type - string | x
+ * 
+ */
 
 export default function Input({ name, type, passwordToMatch, onChange }: InputProps) {
   const [value, setValue] = useState('');

--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -1,16 +1,21 @@
 import { useState } from 'react';
 import Image from 'next/image';
-// Input 사용 시 필요한 props
-// name: input의 이름
-// type: input의 타입
-// passwordToMatch: 비밀번호 확인 시 비교할 비밀번호
-// onChange: input 값 변경 시 실행할 함수
+
+/**
+  *** Input 사용 시 필요한 props ***
+  - name: input의 이름
+  - type: input의 타입
+  - passwordToMatch: 비밀번호 확인 시 비교할 비밀번호
+  - onChange: input 값 변경 시 실행할 함수
+ */
+
 interface InputProps {
-  name: string;
-  type: string;
+  type: 'text' | 'email' | 'password';
+  name: 'name' | 'id' | 'password' | 'password_check';
   passwordToMatch?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
+
 export default function Input({ name, type, passwordToMatch, onChange }: InputProps) {
   const [value, setValue] = useState('');
   const [isValid, setIsValid] = useState(true); // 유효성 검사

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,72 +1,7 @@
-import Image from 'next/image';
-
-console.log('test');
-
 export default function Home() {
   return (
     <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 bg-black p-8 pb-20 font-[family-name:var(--font-geist-sans)] text-gray-300 sm:p-20">
-      <main className="row-start-2 flex size-[4px] flex-col items-center gap-8 sm:items-start">
-        <img className="dark:invert" src="https://nextjs.org/icons/next.svg" alt="Next.js logo" width={180} height={38} />
-        <ol className="list-inside list-decimal text-center font-[family-name:var(--font-geist-mono)] text-sm sm:text-left">
-          <li className="mb-2">
-            화이팅 <div className="rounded bg-black/[.05] px-1 py-0.5 font-semibold dark:bg-white/[.06]">eslint/prettier 설정</div>
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex flex-col items-center gap-4 sm:flex-row">
-          <a
-            className="bg-foreground text-background flex h-10 items-center justify-center gap-2 rounded-full border border-solid border-transparent px-4 text-sm transition-colors hover:bg-[#383838] sm:h-12 sm:px-5 sm:text-base dark:hover:bg-[#ccc]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img className="dark:invert" src="https://nextjs.org/icons/vercel.svg" alt="Vercel logomark" width={20} height={20} />
-            {/* <Image className="dark:invert" src="https://nextjs.org/icons/vercel.svg" alt="Vercel logomark" width={20} height={20} /> */}
-            Deploy now
-          </a>
-          <a
-            className="flex h-10 items-center justify-center rounded-full border border-solid border-black/[.08] px-4 text-sm transition-colors hover:border-transparent hover:bg-[#f2f2f2] sm:h-12 sm:min-w-44 sm:px-5 sm:text-base dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex flex-wrap items-center justify-center gap-6">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="https://nextjs.org/icons/file.svg" alt="File icon" width={16} height={16} />
-          <Image aria-hidden src="https://nextjs.org/icons/file.svg" alt="File icon" width={16} height={16} />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="https://nextjs.org/icons/window.svg" alt="Window icon" width={16} height={16} />
-          <Image aria-hidden src="https://nextjs.org/icons/window.svg" alt="Window icon" width={16} height={16} />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="https://nextjs.org/icons/globe.svg" alt="Globe icon" width={16} height={16} />
-          <Image aria-hidden src="https://nextjs.org/icons/globe.svg" alt="Globe icon" width={16} height={16} />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      
     </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,11 +1321,6 @@ eslint-plugin-prettier@^5.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
-eslint-plugin-react-hooks@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz#72e2eefbac4b694f5324154619fee44f5f60f101"
-  integrity sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==
-
 eslint-plugin-react@^7.33.2, eslint-plugin-react@^7.37.1:
   version "7.37.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz#56493d7d69174d0d828bc83afeffe96903fdadbd"
@@ -2814,16 +2809,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2904,14 +2890,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
<!-- PR 제목은 " [#13] landing-page" 형식으로 작성 -->

## ✅ 체크 리스트

<!-- PR 승인을 받기전 놓친 것 없는지 확인해주세요. -->

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 📝 작업 내용

공용으로 사용하는 input component를 생성.
props로 name과 type은 필수로 들어가야 한다.

현재 name(props)에는 'name', 'id', 'password', 'password_check'만 사용해야한다.
만약 다른 추가사항을 적용하고 싶다면 객체에 추가하여 사용하는 것을 권장한다.

type(props)는 input에 들어갈 type을 집어넣어야 한다.

signup page를 위해 비밀번호 재확인을 할 필요가 있다.
재확인을 위해 비밀번호를 input 컴포넌트에서 password 값을 가져올 필요가 있다.
그래서 onChange={(e) => set예시Password(e.target.value)} 라는 props를 추가하고 useState을 추가하여 사용을 해야 한다.

비밀번호 재확인을 위해 passwordToMatch라는 props를 추가할 수 있다. (
예시)
<Input name="password_check" type="password" passwordToMatch={password} />
이런 식으로 사용하면 좋을 듯 하다.

## 📂 결과물

코드 사용 방식 예시)
<img width="1102" alt="스크린샷 2024-10-18 오후 2 49 33" src="https://github.com/user-attachments/assets/355b6180-a07c-4f03-b847-a813e13987c2">

결과)
<img width="668" alt="스크린샷 2024-10-18 오후 2 50 43" src="https://github.com/user-attachments/assets/ae5369ac-1fdd-4b60-98e1-a93a72a88587">

## 🖥️ 공유 포인트 및 논의 사항

